### PR TITLE
fix(change-cere-logo): Change toolbar with the logo of cere when changee network

### DIFF
--- a/packages/apps-config/src/ui/logos/index.ts
+++ b/packages/apps-config/src/ui/logos/index.ts
@@ -60,7 +60,7 @@ import emptyLogo from './empty.svg';
 // NOTE: This is as retrieved via system.chain RPC
 export const chainLogos: Record<string, unknown> = [
   ['darwinia crab', nodeCrab],
-  ['cere', nodeCere],
+  ['Cerebellum Network Testnet', nodeCere],
   ['Dusty', chainDusty],
   ['Galois', nodeMath],
   ['Kusama', chainKusama], // new name after CC3


### PR DESCRIPTION
Develop blocks explorer: Change the logo to Cere when selected Cere Network. [Notion url](https://www.notion.so/cere/Develop-blocks-explorer-019a2f42e00945aeb3a702dcf8b8700e#730a7e82e95b4488b816ce9d27fcdaad).
Tested with changing Cere and Polkadot.