### PR TITLE
feature(cbi-194-default-full-node-rpc): Add full node in left menu at first order for default

### DIFF
--- a/packages/apps-config/src/endpoints/testing.ts
+++ b/packages/apps-config/src/endpoints/testing.ts
@@ -15,7 +15,7 @@ import { expandEndpoints } from './util';
 //   text: The text to display on the dropdown
 //   value: The actual hosted secure websocket endpoint
 
-export function createTesting (t: TFunction): LinkOption[] {
+export function createTesting(t: TFunction): LinkOption[] {
   return expandEndpoints(t, [
     // polkadot test relays
     createRococo(t),
@@ -30,7 +30,14 @@ export function createTesting (t: TFunction): LinkOption[] {
     },
     {
       info: 'cere',
-      text: t('rpc.cere', 'Cerebellum Network', { ns: 'apps-config' }),
+      text: t('rpc.cere.fullnode', 'Cerebellum Network Full Node', { ns: 'apps-config' }),
+      providers: {
+        CerebellumNetwork: 'wss://testnet-node-1.cere.network:9945'
+      }
+    },
+    {
+      info: 'cere',
+      text: t('rpc.cere', 'Cerebellum Network Validator Node', { ns: 'apps-config' }),
       providers: {
         CerebellumNetwork: 'wss://testnet-node-1.cere.network:9945'
       }

--- a/packages/apps/public/locales/en/apps-config.json
+++ b/packages/apps/public/locales/en/apps-config.json
@@ -6,6 +6,7 @@
   "rpc.canvas": "Canvas",
   "rpc.centrifuge": "Centrifuge",
   "rpc.cere": "Cerebellum Network",
+  "rpc.cere.fullnode": "Cerebellum Network Full Node",
   "rpc.crab": "Darwinia Crab",
   "rpc.crust.network": "Crust Maxwell CC2",
   "rpc.custom": "Custom environment",


### PR DESCRIPTION
Block Viewer uses Full Node DNS as a default. Ticket [url](https://cerenetwork.atlassian.net/browse/CBI-194)
