### PR TITLE
[palark][38643] Deploy stage to Cloudflare Pages

### DIFF
--- a/.github/workflows/stage.yaml
+++ b/.github/workflows/stage.yaml
@@ -1,21 +1,23 @@
 name: Release to stage
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'release/**'
       - 'hotfix/**'
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
   build-and-deploy:
-    uses: Cerebellum-Network/reusable-workflows/.github/workflows/deploy-to-cloudfront.yaml@master
+    uses: Cerebellum-Network/reusable-workflows/.github/workflows/deploy-to-cloudflare-pages.yaml@master
     with:
+      project_name: 'cere-explorer-stage'
       build_container: 'node:20-buster'
       install_packages_command: 'yarn install'
       build_command: 'yarn build'
       path_to_static_files_to_upload: 'packages/apps/build'
-      s3_bucket_name: 'explorer.stage.cere.network-static'
-      aws_account_id: ${{ vars.CERE_IO_AWS_ACCOUNT_ID }}
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Switch stage deploy from S3+CloudFront to Cloudflare Pages (project cere-explorer-stage) via reusable workflow deploy-to-cloudflare-pages. Validated: run 29919566602, explorer.stage.cere.network cut over. Trigger on release/**+hotfix/** kept, workflow_dispatch added.