### PR TITLE
[palark][38643] Deploy prod to Cloudflare Pages

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -1,20 +1,22 @@
 name: Release to prod
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
   build-and-deploy:
-    uses: Cerebellum-Network/reusable-workflows/.github/workflows/deploy-to-cloudfront.yaml@master
+    uses: Cerebellum-Network/reusable-workflows/.github/workflows/deploy-to-cloudflare-pages.yaml@master
     with:
+      project_name: 'cere-explorer-prod'
       build_container: 'node:20-buster'
       install_packages_command: 'yarn install'
       build_command: 'yarn build'
       path_to_static_files_to_upload: 'packages/apps/build'
-      s3_bucket_name: 'explorer.cere.network-static'
-      aws_account_id: ${{ vars.CERE_IO_AWS_ACCOUNT_ID }}
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Switch prod deploy from S3+CloudFront to Cloudflare Pages (project cere-explorer-prod) via reusable workflow deploy-to-cloudflare-pages. Validated: run 29923273671, explorer.cere.network cut over.